### PR TITLE
Add multiple file extensions support through HtmlPages.prototype.pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function HtmlPages(config) {
   var pluginConfig = config.plugins.htmlPages || {};
   this.destinationFn = pluginConfig.destination || this.DEFAULT_DESTINATION_FN;
   this.disabled = pluginConfig.disabled || this.DISABLED_SETTING;
+  this.pattern = pluginConfig.pattern || this.DEFAULT_PATTERN;
   this.htmlMinOptions = pluginConfig.htmlMin ?
     _.clone(pluginConfig.htmlMin) :
     this.DEFAULT_HTMLMIN_OPTIONS;
@@ -21,7 +22,8 @@ function HtmlPages(config) {
 
 HtmlPages.prototype.brunchPlugin = true;
 HtmlPages.prototype.type = "template";
-HtmlPages.prototype.extension = "html";
+
+HtmlPages.prototype.DEFAULT_PATTERN = /\.html$/;
 
 HtmlPages.prototype.DEFAULT_DESTINATION_FN = function (path) {
   return path.replace(/^app[\/\\](.*)\.html$/, "$1.html");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-pages-brunch",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Adds HTMLMinifier support to brunch",
   "author": "Anatoly Ostrovsky (anatolyostrovsky@gmail.com)",
   "homepage": "https://github.com/tolyo/html-pages-brunch",


### PR DESCRIPTION
### Add optionnal files pattern

```
htmlPages:
      pattern: /\.(html|htm|xml)$/
```
